### PR TITLE
Including links to the Linux version of OHDSI-in-a-Box

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,50 @@
 ## OHDSI-in-a-Box
 
-Quickly deploy a single instance implementation of OHDSI tools and sample data for personal learning and training enviroments.  If you are looking to deploy a enterprise, scalable OHDSI architecture then check out the [OHDSIonAWS project](https://github.com/OHDSI/OHDSIonAWS).  
+Quickly deploy a single instance implementation of OHDSI tools and sample data for personal learning and training enviroments.  If you are looking to deploy a enterprise, scalable OHDSI architecture then check out the [OHDSIonAWS project](https://github.com/OHDSI/OHDSIonAWS).  A Linux and Windows version of this environment are offered.  Both versions have the same set of OHDSI tools.  The Windows version uses 'pgAdmin 4' to allow access to the Postgres database while the Linux version uses 'SQL Workbench'.  The Linux version is ~40% less expensive to run, depending on the exact AWS instance type you choose.
 
+## Linux Version
+| AWS Region Code | Name | Launch |
+| --- | --- | --- 
+| us-east-1 |US East (N. Virginia)| [![cloudformation-launch-stack](images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=OHDSI&templateURL=https://s3.amazonaws.com/ohdsi-rstudio/ohdsi-in-a-box-linux.yaml) |
+| eu-west-1 |EU (Ireland)| [![cloudformation-launch-stack](images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/new?stackName=OHDSI&templateURL=https://s3.amazonaws.com/ohdsi-rstudio/ohdsi-in-a-box-linux.yaml) |
+| ap-northeast-1 |AP (Tokyo)| [![cloudformation-launch-stack](images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/new?stackName=OHDSI&templateURL=https://s3.amazonaws.com/ohdsi-rstudio/ohdsi-in-a-box-linux.yaml) |
+
+| OHDSI Component | Version |
+| --- | --- 
+| OMOP Common Data Model | v5.3.1 |
+| Atlas | v2.7.6 |
+| WebAPI | v2.7.6 | 
+| Usagi | v1.1.6 |
+| WhiteRabbit | v0.7.8 |
+| RabbitInAHat| v0.7.8 |
+| Achilles | v1.6.3 |
+| PatientLevelPrediction | v3.0.6 |
+| DatabaseConnector | v2.4.1 |
+| DatabaseConnectorJars | v1.0.0 |
+| SqlRender | v1.6.2 |
+| OhdsiRTools | v1.7.0 |
+| FeatureExtraction | v2.2.2 |
+| Cyclops | v2.0.2 |
+| OhdsiSharing | v0.1.3 |
+
+| Sample Data Source | Size |
+| --- | --- 
+| CMS DeSynPUF | 100k persons |
+| CMS DeSynPUF | 1k persons |
+| Synthea | 1k persons |
+
+**RDP username:** ohdsi
+**RDP password:** this is specified as a parameter during deployment
+**Postgres username:** ohdsi
+**Postgres password:** this is specified as a parameter during deployment
+
+
+## Windows Version
 | AWS Region Code | Name | Launch |
 | --- | --- | --- 
 | us-east-1 |US East (N. Virginia)| [![cloudformation-launch-stack](images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=OHDSI&templateURL=https://s3.amazonaws.com/ohdsi-rstudio/ohdsi-in-a-box.yaml) |
 | eu-west-1 |EU (Ireland)| [![cloudformation-launch-stack](images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/new?stackName=OHDSI&templateURL=https://s3.amazonaws.com/ohdsi-rstudio/ohdsi-in-a-box.yaml) |
 | ap-northeast-1 |AP (Tokyo)| [![cloudformation-launch-stack](images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/new?stackName=OHDSI&templateURL=https://s3.amazonaws.com/ohdsi-rstudio/ohdsi-in-a-box.yaml) |
-
 
 | OHDSI Component | Version |
 | --- | --- 
@@ -27,19 +64,16 @@ Quickly deploy a single instance implementation of OHDSI tools and sample data f
 | Cyclops | v2.0.2 |
 | OhdsiSharing | v0.1.3 |
 
-
 | Sample Data Source | Size |
 | --- | --- 
 | CMS DeSynPUF | 100k persons |
 | Synthea | 1k persons |
 
-**Windows username:** ohdsi
-
-**Windows password:** this is specified as a parameter during deployment
-
+**RDP username:** ohdsi
+**RDP password:** this is specified as a parameter during deployment
 **Postgres username:** postgres
-
 **Postgres password:** ohdsi
+
 
 ## OHDSI-in-a-Box Architecture
 OHDSI-in-a-Box is specifically created as a learning environment, and is used in most of the tutorials provided by the OHDSI community. It includes many OHDSI tools, sample data sets, RStudio and other supporting software in a single, low cost Windows virtual machine. A PostgreSQL database is used to store the CDM and also to store the intermediary results from ATLAS. The OMOP CDM data mapping and ETL tools are also included in OHDSI-in-a-Box. A high-level diagram showing how the different components of OHDSI map to AWS Services is shown below.  


### PR DESCRIPTION
The Linux version is ~40% cheaper to run, on average.  Including links to deploy this version.