### PR TITLE
Fix/nodedrift sdk3

### DIFF
--- a/build-ohdsi-in-a-box-linux.yaml
+++ b/build-ohdsi-in-a-box-linux.yaml
@@ -18,6 +18,7 @@ Metadata:
       Parameters:
         - InstancePassword
         - AccessCidr
+        - EC2KeyName
     - Label:
         default: Scaling
       Parameters:
@@ -31,6 +32,8 @@ Metadata:
         - Subnet
 
     ParameterLabels:
+      KeyPair:
+        default: Available keypair fo accessing the
       InstancePassword:
         default: Instance Password
       AccessCidr:

--- a/ohdsi-in-a-box-linux.yaml
+++ b/ohdsi-in-a-box-linux.yaml
@@ -115,7 +115,7 @@ Parameters:
 Mappings:
   RegionMap:
     us-east-1:
-      AMI: ami-04fc41bba02647770
+      AMI: ami-0e47b90151c13585a
 #    us-east-2:
 #      AMI: 
 #    us-west-1:

--- a/ohdsi-in-a-box-linux.yaml
+++ b/ohdsi-in-a-box-linux.yaml
@@ -201,8 +201,14 @@ Resources:
       Role: !GetAtt LambdaExecutionRole.Arn
       Code:
         ZipFile: !Sub |
-          var response = require('cfn-response');
-          var AWS = require('aws-sdk');
+          const response = require('cfn-response');
+
+          const {
+            EC2,
+            waitUntilInstanceRunning,
+            waitUntilInstanceTerminated
+          } = require('@aws-sdk/client-ec2');
+
           exports.handler = function(event, context) {
             var physicalId = event.PhysicalResourceId || 'none';
             function success(data) {
@@ -211,29 +217,35 @@ Resources:
             function failed(e) {
               return response.send(event, context, response.FAILED, e, physicalId);
             }
-            var ec2 = new AWS.EC2();
+            var ec2 = new EC2();
             var instances;
             if (event.RequestType == 'Create') {
               var launchParams = event.ResourceProperties;
               delete launchParams.ServiceToken;
-              ec2.runInstances(launchParams).promise().then((data)=> {
+              ec2.runInstances(launchParams).then((data)=> {
                 instances = data.Instances.map((data)=> data.InstanceId);
                 physicalId = instances.join(':');
-                return ec2.waitFor('instanceRunning', {InstanceIds: instances}).promise();
+                return waitUntilInstanceRunning({
+                  client: ec2,
+                  maxWaitTime: 200
+                }, {InstanceIds: instances});
               }).then((data)=> success({Instances: instances})
               ).catch((e)=> failed(e));
             } else if (event.RequestType == 'Delete') {
               if (physicalId == 'none') {return success({});}
               var deleteParams = {InstanceIds: physicalId.split(':')};
-              ec2.terminateInstances(deleteParams).promise().then((data)=>
-                ec2.waitFor('instanceTerminated', deleteParams).promise()
+              ec2.terminateInstances(deleteParams).then((data)=>
+                waitUntilInstanceTerminated({
+                  client: ec2,
+                  maxWaitTime: 200
+                }, deleteParams)
               ).then((data)=>success({})
               ).catch((e)=>failed(e));
             } else {
               return failed({Error: "In-place updates not supported."});
             }
           };
-      Runtime: nodejs12.x
+      Runtime: nodejs20.x
       Timeout: 300
   LambdaExecutionRole:
     Type: AWS::IAM::Role

--- a/ohdsi-in-a-box.yaml
+++ b/ohdsi-in-a-box.yaml
@@ -115,7 +115,7 @@ Parameters:
 Mappings:
   RegionMap:
     us-east-1:
-      AMI: ami-085db92dc87073f35
+      AMI: ami-0e47b90151c13585a
 #    us-east-2:
 #      AMI: 
 #    us-west-1:

--- a/ohdsi-in-a-box.yaml
+++ b/ohdsi-in-a-box.yaml
@@ -204,8 +204,14 @@ Resources:
       Role: !GetAtt LambdaExecutionRole.Arn
       Code:
         ZipFile: !Sub |
-          var response = require('cfn-response');
-          var AWS = require('aws-sdk');
+          const response = require('cfn-response');
+
+          const {
+            EC2,
+            waitUntilInstanceRunning,
+            waitUntilInstanceTerminated
+          } = require('@aws-sdk/client-ec2');
+
           exports.handler = function(event, context) {
             var physicalId = event.PhysicalResourceId || 'none';
             function success(data) {
@@ -214,29 +220,35 @@ Resources:
             function failed(e) {
               return response.send(event, context, response.FAILED, e, physicalId);
             }
-            var ec2 = new AWS.EC2();
+            var ec2 = new EC2();
             var instances;
             if (event.RequestType == 'Create') {
               var launchParams = event.ResourceProperties;
               delete launchParams.ServiceToken;
-              ec2.runInstances(launchParams).promise().then((data)=> {
+              ec2.runInstances(launchParams).then((data)=> {
                 instances = data.Instances.map((data)=> data.InstanceId);
                 physicalId = instances.join(':');
-                return ec2.waitFor('instanceRunning', {InstanceIds: instances}).promise();
+                return waitUntilInstanceRunning({
+                  client: ec2,
+                  maxWaitTime: 200
+                }, {InstanceIds: instances});
               }).then((data)=> success({Instances: instances})
               ).catch((e)=> failed(e));
             } else if (event.RequestType == 'Delete') {
               if (physicalId == 'none') {return success({});}
               var deleteParams = {InstanceIds: physicalId.split(':')};
-              ec2.terminateInstances(deleteParams).promise().then((data)=>
-                ec2.waitFor('instanceTerminated', deleteParams).promise()
+              ec2.terminateInstances(deleteParams).then((data)=>
+                waitUntilInstanceTerminated({
+                  client: ec2,
+                  maxWaitTime: 200
+                }, deleteParams)
               ).then((data)=>success({})
               ).catch((e)=>failed(e));
             } else {
               return failed({Error: "In-place updates not supported."});
             }
           };
-      Runtime: nodejs12.x
+      Runtime: nodejs20.x
       Timeout: 300
   LambdaExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Looking to modernize this a little bit and include another guide/dialect for intersystems iris.

Nodejs drift in the current master branch makes this stack fail currently.

This branch upgrades to nodejs20 to move past the deprecation that coincidentally required an update to aws-sdk3 as well for the function.

`npx aws-sdk-js-codemod -t v2-to-v3 index.js`   worked out pretty well...

I built and shared out my own ami for testing and updated us-east-1 ami, launches successfully (linux).

![image](https://github.com/user-attachments/assets/de250ec3-de76-4d96-a589-fbdecb805ea8)

Not seeing a build stack for the windows ami unless I am missing something...

will keep the changes small and rock the boat to functional in subsequent PR's

